### PR TITLE
Fixes warning: Addresses CoolProp Issue #1277

### DIFF
--- a/IF97.h
+++ b/IF97.h
@@ -2075,6 +2075,7 @@ namespace IF97
                 case NONE:
                 default: return subregion;
             }
+            return subregion;  // in case no adjustment needs to be made
         };
 
         double output(IF97parameters key, double T, double p, IF97SatState State){


### PR DESCRIPTION
Potential (maybe) to reach end of non-void function  (SatSubRegionAdjust) without a return value.  Addressed with a returned default value **_after_** the switch.