### PR TITLE
Implementation of Backwards Equations for T(p,h) & T(p,s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*~
+
+/wrapper/Mathcad/*.sdf
+/wrapper/Mathcad/*.suo
+/wrapper/Mathcad/*.user
+/wrapper/Mathcad/Release
+/wrapper/Mathcad/Debug
+/wrapper/Mathcad/ipch

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 
+/build*
+
 /wrapper/Mathcad/*.sdf
 /wrapper/Mathcad/*.suo
 /wrapper/Mathcad/*.user

--- a/IF97.cpp
+++ b/IF97.cpp
@@ -10,7 +10,7 @@ int main(){
     printf("*****************************************************************\n");
     printf("******************** Verification Tables ************************\n");
     printf("* Tables below are printed for verification.  Unless otherwise  *\n");
-    printf("* noted, tables are reporoduced from the                        *\n");
+    printf("* noted, tables are reproduced from the                         *\n");
     printf("* \"Revised Release on the IAPWS Industrial Formulation 1997\"    *\n");
     printf("* IAPWS R7-97(2012).                                            *\n");
     printf("*****************************************************************\n\n\n");
@@ -55,7 +55,7 @@ int main(){
     printf("        formulas from the (2014) \"Revised Supplementary       \n");
     printf("        Release on Backward Equations for Specific Volume\".   \n");
     printf("        As a result, the values below will not be exactly      \n");
-    printf("        the Table 33 values, but should be withing +/-1.0E-6.  \n");
+    printf("        the Table 33 values, but should be within +/-1.0E-6.  \n");
     printf("        of the published values.                               \n\n");
 
     T1 = 1500, T2 = 1500, T3 = 2000, p1 = 0.5e6, p2 = 30e6, p3 = 30e6;

--- a/IF97.cpp
+++ b/IF97.cpp
@@ -7,10 +7,19 @@ int main(){
 
     using namespace IF97;
 
+    printf("*****************************************************************\n");
+    printf("******************** Verification Tables ************************\n");
+    printf("* Tables below are printed for verification.  Unless otherwise  *\n");
+    printf("* noted, tables are reporoduced from the                        *\n");
+    printf("* \"Revised Release on the IAPWS Industrial Formulation 1997\"    *\n");
+    printf("* IAPWS R7-97(2012).                                            *\n");
+    printf("*****************************************************************\n\n\n");
+
+
     double T1 = 300, T2 = 300, T3 = 500, p1 = 3e6, p2 = 80e6, p3 = 3e6;
-    printf("***************************************************************\n");
-    printf("******************** Table 5 - Region 1 ***********************\n");
-    printf("***************************************************************\n");
+    printf("*****************************************************************\n");
+    printf("******************** Table 5 - Region 1 *************************\n");
+    printf("*****************************************************************\n");
     printf("%5s %11.9e %11.9e %11.9e\n", "v", 1/rhomass_Tp(T1, p1), 1/rhomass_Tp(T2, p2), 1/rhomass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "h", hmass_Tp(T1, p1), hmass_Tp(T2, p2), hmass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "u", umass_Tp(T1, p1), umass_Tp(T2, p2), umass_Tp(T3, p3));
@@ -32,14 +41,22 @@ int main(){
 
     T1 = 650, T2 = 650, T3 = 750, p1 = 25.5837018e6, p2 = 22.2930643e6, p3 = 78.3095639e6;
     printf("***************************************************************\n");
-    printf("******************* Table 33 - Region 3 ***********************\n");
+    printf("******************* Table 33* - Region 3 **********************\n");
     printf("***************************************************************\n");
     printf("%5s %11.9e %11.9e %11.9e\n", "rho", rhomass_Tp(T1, p1), rhomass_Tp(T2, p2), rhomass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "h", hmass_Tp(T1, p1), hmass_Tp(T2, p2), hmass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "s", smass_Tp(T1, p1), smass_Tp(T2, p2), smass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "cp", cpmass_Tp(T1, p1), cpmass_Tp(T2, p2), cpmass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "w", speed_sound_Tp(T1, p1), speed_sound_Tp(T2, p2), speed_sound_Tp(T3, p3));
-    printf("***************************************************************\n\n");
+    printf("***************************************************************\n");
+    printf("* NOTE: This table is evaluated by first evaluating density    \n");
+    printf("        from the three pressure values of Table 33 in the      \n");
+    printf("        2007 Revised Release document, using the reverse       \n");
+    printf("        formulas from the (2014) \"Revised Supplementary       \n");
+    printf("        Release on Backward Equations for Specific Volume\".   \n");
+    printf("        As a result, the values below will not be exactly      \n");
+    printf("        the Table 33 values, but should be withing +/-1.0E-6.  \n");
+    printf("        of the published values.                               \n\n");
 
     T1 = 1500, T2 = 1500, T3 = 2000, p1 = 0.5e6, p2 = 30e6, p3 = 30e6;
     printf("***************************************************************\n");
@@ -50,7 +67,90 @@ int main(){
     printf("%5s %11.9e %11.9e %11.9e\n", "s", smass_Tp(T1, p1), smass_Tp(T2, p2), smass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "cp", cpmass_Tp(T1, p1), cpmass_Tp(T2, p2), cpmass_Tp(T3, p3));
     printf("%5s %11.9e %11.9e %11.9e\n", "w", speed_sound_Tp(T1, p1), speed_sound_Tp(T2, p2), speed_sound_Tp(T3, p3));
-    printf("***************************************************************\n");
+    printf("***************************************************************\n\n\n");
+
+    printf("**************** Reverse Functions T(p,h) & T(p,s) ********************\n\n");
+
+    p1  = 3.0e6; p2 = 80e6; p3 = 80e6; double h1 = 500e3, h2 = 500e3, h3 = 1500e3;
+    double s1 = 0.5e3, s2 = 0.5e3, s3 = 3e3;
+    printf("_______________________________________________________________________\n");
+    printf("                                Region 1                               \n");
+    printf("_______________________________________________________________________\n");
+    printf("              Table 7              |               Table 9             \n");
+    printf("___________________________________|___________________________________\n");
+    printf(" p/MPa  h/(kJ/kg)        T/K       | p/MPa s/(kJ/kg-K)       T/K       \n");
+    printf("___________________________________|___________________________________\n");
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %3.1f      %11.8e \n",p1/1e6,h1/1e3,T_phmass(p1,h1),
+                                                                            p1/1e6,s1/1e3,T_psmass(p1,s1));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %3.1f      %11.8e \n",p2/1e6,h2/1e3,T_phmass(p2,h2),
+                                                                            p2/1e6,s2/1e3,T_psmass(p2,s2));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %3.1f      %11.8e \n",p3/1e6,h3/1e3,T_phmass(p3,h3),
+                                                                            p3/1e6,s3/1e3,T_psmass(p3,s3));
+    printf("_______________________________________________________________________\n\n\n");
+
+    p1  = 0.001e6; p2 = 3e6; p3 = 3e6; h1 = 3000e3; h2 = 3000e3; h3 = 4000e3;
+    double p1s = 0.1e6, p2s = 0.1e6, p3s = 2.5e6; s1 = 7.5e3, s2 = 8e3, s3 = 8e3;
+    printf("_______________________________________________________________________\n");
+    printf("                           Region 2a, 2b, 2c                           \n");
+    printf("_______________________________________________________________________\n");
+    printf("              Table 24             |               Table 29            \n");
+    printf("___________________________________|___________________________________\n");
+    printf(" p/MPa  h/(kJ/kg)        T/K       | p/MPa s/(kJ/kg-K)       T/K       \n");
+    printf("___________________________________|___________________________________\n");
+    printf("  %5.3f   %4.0f     %11.8e |  %3.1f     %3.1f      %11.8e \n",p1/1e6,h1/1e3,T_phmass(p1,h1),
+                                                                          p1s/1e6,s1/1e3,T_psmass(p1s,s1));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.1f     %3.1f      %11.8e \n",p2/1e6,h2/1e3,T_phmass(p2,h2),
+                                                                            p2s/1e6,s2/1e3,T_psmass(p2s,s2));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.1f     %3.1f      %11.8e \n",p3/1e6,h3/1e3,T_phmass(p3,h3),
+                                                                            p3s/1e6,s3/1e3,T_psmass(p3s,s3));
+    printf("___________________________________|___________________________________\n");
+    p1  = 5e6; p2  = 5e6; p3  = 25e6; h1 = 3500e3; h2 = 4000e3; h3 = 3500e3;
+    p1s = 8e6; p2s = 8e6; p3s = 90e6; s1 = 6e3;    s2 = 7.5e3;  s3 = 6e3;
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %3.1f      %11.8e \n",p1/1e6,h1/1e3,T_phmass(p1,h1),
+                                                                            p1s/1e6,s1/1e3,T_psmass(p1s,s1));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %3.1f      %11.8e \n",p2/1e6,h2/1e3,T_phmass(p2,h2),
+                                                                            p2s/1e6,s2/1e3,T_psmass(p2s,s2));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %3.1f      %11.8e \n",p3/1e6,h3/1e3,T_phmass(p3,h3),
+                                                                            p3s/1e6,s3/1e3,T_psmass(p3s,s3));
+    printf("_______________________________________________________________________\n\n");
+    p1  = 40e6; p2  = 60e6; p3  = 60e6; h1 = 2700e3; h2 = 2700e3; h3 = 3200e3;
+    p1s = 20e6; p2s = 80e6; p3s = 80e6; s1 = 5.75e3; s2 = 5.25e3; s3 = 5.75e3;
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %4.2f     %11.8e \n",p1/1e6,h1/1e3,T_phmass(p1,h1),
+                                                                          p1s/1e6,s1/1e3,T_psmass(p1s,s1));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %4.2f     %11.8e \n",p2/1e6,h2/1e3,T_phmass(p2,h2),
+                                                                          p2s/1e6,s2/1e3,T_psmass(p2s,s2));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f     %4.2f     %11.8e \n",p3/1e6,h3/1e3,T_phmass(p3,h3),
+                                                                          p3s/1e6,s3/1e3,T_psmass(p3s,s3));
+    printf("_______________________________________________________________________\n\n\n");
+
+    printf("_______________________________________________________________________\n");
+    printf("                             Region 3a, 3b                             \n");
+    printf("_______________________________________________________________________\n");
+    printf("              Table 5*             |               Table 12*           \n");
+    printf("___________________________________|___________________________________\n");
+    printf(" p/MPa  h/(kJ/kg)        T/K       | p/MPa s/(kJ/kg-K)       T/K       \n");
+    printf("___________________________________|___________________________________\n");
+    p1  = 20e6; p2  = 50e6; p3  = 100e6; h1 = 1700e3; h2 = 2000e3; h3 = 2100e3;
+                                         s1 = 3.8e3;  s2 = 3.6e3;  s3 = 4.0e3;
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f      %3.1f     %11.8e \n",p1/1e6,h1/1e3,T_phmass(p1,h1),
+                                                                          p1/1e6,s1/1e3,T_psmass(p1,s1));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f      %3.1f     %11.8e \n",p2/1e6,h2/1e3,T_phmass(p2,h2),
+                                                                          p2/1e6,s2/1e3,T_psmass(p2,s2));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f      %3.1f     %11.8e \n",p3/1e6,h3/1e3,T_phmass(p3,h3),
+                                                                          p3/1e6,s3/1e3,T_psmass(p3,s3));
+    printf("_______________________________________________________________________\n\n");
+    h1 = 2500e3; h2 = 2400e3; h3 = 2700e3;
+    s1 = 5.0e3;  s2 = 4.5e3;  s3 = 5.0e3;
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f      %3.1f     %11.8e \n",p1/1e6,h1/1e3,T_phmass(p1,h1),
+                                                                          p1/1e6,s1/1e3,T_psmass(p1,s1));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f      %3.1f     %11.8e \n",p2/1e6,h2/1e3,T_phmass(p2,h2),
+                                                                          p2/1e6,s2/1e3,T_psmass(p2,s2));
+    printf("  %3.0f     %4.0f     %11.8e |  %3.0f      %3.1f     %11.8e \n",p3/1e6,h3/1e3,T_phmass(p3,h3),
+                                                                          p3/1e6,s3/1e3,T_psmass(p3,s3));
+    printf("_______________________________________________________________________\n");
+    printf("* The Region 3a, 3b formulation comes from the 2014 \"Revised \n");
+    printf("  Supplementary Release on Backward Equations for the Functions\n");
+    printf("  T(p,h), v(p,h) and T(p,s), v(p,s) for Region 3 [IAPWS SR3-03(2014)]\" \n");
 
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ Usage
 
 See ``IF97.cpp``.  
 
-The primary functions needed are ``rhomass_TP(T,p)``, ``hmass_Tp(T,p)``, etc. where in all cases, the units are base-SI units (Pa, K, J/kg, etc.)
+The primary functions needed are ``rhomass_TP(T,p)``, ``hmass_Tp(T,p)``, etc. where in all cases, the units are base-SI units (Pa, K, J/kg, etc.)  
+  
+Liquid and vapor values along the saturation curve can be obtained using ``rholiq_p(p)``, ``rhovap_p(p)``, ``sliq_p(p)``, ``svap_p(p)``, etc.; all as a function of pressure.
 
 There are also ``Tsat97(p)`` and ``psat97(T)`` functions to get values from the saturation line.
+
+Backward functions have been implemented to return temperature as a function of pressure and either enthalpy or entropy; ``T_phmass(p,h)`` and ``T_psmass(p,s)``.
 
 License
 -------

--- a/wrapper/Mathcad/IF97.cpp
+++ b/wrapper/Mathcad/IF97.cpp
@@ -10,11 +10,12 @@
 //  2.6X longer than the supplemental equations alone.
 #define REGION3_ITERATE
 
-#define PSTAR 1e6          // Used to put [MPa] values in [Pa]
+// #define IAPWS_UNITS          // Set to use IAPWS Units of [MPa] and [kJ] (instead of [Pa] and [J] )
 #include "../../IF97.h"
 
 // Mathcad Error Codes
-enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_OUT_OF_RANGE, SATURATED, NO_SOLUTION_FOUND, D_OUT_OF_RANGE, NUMBER_OF_ERRORS};
+enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_OUT_OF_RANGE, SATURATED, NO_SOLUTION_FOUND, 
+          D_OUT_OF_RANGE, H_OUT_OF_RANGE, S_OUT_OF_RANGE, NUMBER_OF_ERRORS};
 
     // Table of Error Messages
     // These message strings MUST be in the order of the Error Code enumeration above, with the last being a dummy value for error count
@@ -28,21 +29,10 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
         "Saturated Conditions",
         "No Solution Found",
         "Density out of Range",
+        "Enthalpy out of Range",
+        "Entropy out of Range",
         "Error Count - Not Used"
     };
-
-    const double Ttrip   = 273.16;              // Triple point in [K]
-    const double Ptrip   = 611.657e-6*PSTAR;    // Triple point in [MPa] 
-    const double Tcrit   = 647.096;             // Critical point in [K]
-    const double Pcrit   = 22.064*PSTAR;        // Critical point in [MPa]
-    const double rhocrit = 322.0;               // Critical point in [kg/m³]
-    const double Tmax    = 1073.15;             // Max Temperature [K]
-    const double Pmax    = 100.0*PSTAR;         // Max Pressure [MPa] 
-    const double Text    = 2273.15;             // Extended (Region 5) Temperature Limit (Region 5) [K]
-    const double Pext    = 50.0*PSTAR;          // Extended (Region 5) Pressure Limit (Region 5) [MPa]
-    const double P23min  = 16.5292*PSTAR;       // Min Pressure on Region23 boundary curve; Max is Pmax
-    const double T23min  = 623.15;              // Min Temperature on Region23 boundary curve
-    const double T23max  = 863.15;              // Max Temperature on Region23 boundary curve
 
     // Include the Function call stubs here:
     //
@@ -97,6 +87,15 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
     // *************************************************************
     #include ".\includes\p23.h"
     #include ".\includes\t23.h"
+    #include ".\includes\regionph.h"
+    #include ".\includes\regionps.h"
+    #include ".\includes\h3ab.h"
+    #include ".\includes\h2bc.h"
+    // *************************************************************
+    // Reverse Functions
+    // *************************************************************
+    #include ".\includes\tph.h"
+    #include ".\includes\tps.h"
 
     // DLL entry point code.  the _CRT_INIT function is needed
     // if you are using Microsoft's 32 bit compiler
@@ -181,6 +180,15 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
                     // *************************************************************
                     CreateUserFunction( hDLL, &if97_p23 );
                     CreateUserFunction( hDLL, &if97_t23 );
+                    CreateUserFunction( hDLL, &if97_h2bc );
+                    CreateUserFunction( hDLL, &if97_h3ab );
+                    CreateUserFunction( hDLL, &if97_regionph );
+                    CreateUserFunction( hDLL, &if97_regionps );
+                    // *************************************************************
+                    // Reverse functions
+                    // *************************************************************
+                    CreateUserFunction( hDLL, &if97_tph );
+                    CreateUserFunction( hDLL, &if97_tps );
                     break;
                     }
 
@@ -199,13 +207,3 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
     }
 
   
-#undef  PSTAR
-#undef  MUST_BE_REAL
-#undef  INSUFFICIENT_MEMORY
-#undef  INTERRUPTED
-#undef  T_OUT_OF_RANGE
-#undef  P_OUT_OF_RANGE
-#undef  SATURATED
-#undef  NO_SOLUTION_FOUND
-#undef  D_OUT_OF_RANGE
-#undef  NUMBER_OF_ERRORS

--- a/wrapper/Mathcad/IF97.vcxproj
+++ b/wrapper/Mathcad/IF97.vcxproj
@@ -50,11 +50,20 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;IF97_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>C:\Program Files %28x86%29\Mathcad\Mathcad 15\userefi\microsft\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>C:\Program Files %28x86%29\Mathcad\Mathcad 15\userefi\microsft\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>mcaduser.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetPath)" ..\..\..\ /rqky</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy release DLL </Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -95,6 +104,8 @@
     <ClInclude Include="includes\cvf.h" />
     <ClInclude Include="includes\cvg.h" />
     <ClInclude Include="includes\cvtp.h" />
+    <ClInclude Include="includes\h2bc.h" />
+    <ClInclude Include="includes\h3ab.h" />
     <ClInclude Include="includes\hf.h" />
     <ClInclude Include="includes\hg.h" />
     <ClInclude Include="includes\htp.h" />
@@ -102,6 +113,8 @@
     <ClInclude Include="includes\pcrit.h" />
     <ClInclude Include="includes\psatt.h" />
     <ClInclude Include="includes\ptrip.h" />
+    <ClInclude Include="includes\regionph.h" />
+    <ClInclude Include="includes\regionps.h" />
     <ClInclude Include="includes\rhof.h" />
     <ClInclude Include="includes\rhog.h" />
     <ClInclude Include="includes\rhotp.h" />
@@ -110,6 +123,8 @@
     <ClInclude Include="includes\stp.h" />
     <ClInclude Include="includes\t23.h" />
     <ClInclude Include="includes\tcrit.h" />
+    <ClInclude Include="includes\tph.h" />
+    <ClInclude Include="includes\tps.h" />
     <ClInclude Include="includes\tsatp.h" />
     <ClInclude Include="includes\ttrip.h" />
     <ClInclude Include="includes\uf.h" />

--- a/wrapper/Mathcad/README.md
+++ b/wrapper/Mathcad/README.md
@@ -21,10 +21,10 @@ To Build
 
 * Build the if97 DLL in Visual Studio.  The project will auotmatically copy the DLL to the appropriate Mathcad installation directory.  You may have to allow user write access to both:
 
-	``C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\userefi``
+	``C:\Program Files (x86)\Mathcad\Mathcad 15\userefi``
 	
     and
 		
-	``C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\doc\\funcdoc``
+	``C:\Program Files (x86)\Mathcad\Mathcad 15\doc\funcdoc``
 
 * Follow the above instructions for use.

--- a/wrapper/Mathcad/README.md
+++ b/wrapper/Mathcad/README.md
@@ -8,11 +8,11 @@ To Use
 
 * Compile in VS2010 or later using the solution and project files
 
-* Copy the if97.dll file to C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\userefi or equivalent for your version (this will be done automatically by the project)
+* Copy the if97.dll file to C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\userefi or equivalent for your version (this will be done automatically by the project)  
+  
+* Copy the IF97_EN.xml to C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\doc\\funcdoc.  Functions and descriptions will then be available in the Mathcad 15 interface under Insert|Function or the Functions button on the toolbar.
 
-* Functions and descriptions will be available in Mathcad 15 under Insert|Function or the Functions button on the toolbar.
-
-* View if97_verification.xmcd for examples of using the functions.
+* View if97_verification.pdf for examples of using the functions.
 
 To Build
 ========
@@ -21,10 +21,10 @@ To Build
 
 * Build the if97 DLL in Visual Studio.  The project will auotmatically copy the DLL to the appropriate Mathcad installation directory.  You may have to allow user write access to both:
 
-	C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\userefi
+	``C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\userefi``
 	
-		and
+    and
 		
-	C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\doc\\funcdoc
+	``C:\\Program Files (x86)\\Mathcad\\Mathcad 15\\doc\\funcdoc``
 
 * Follow the above instructions for use.

--- a/wrapper/Mathcad/if97_EN.xml
+++ b/wrapper/Mathcad/if97_EN.xml
@@ -227,5 +227,20 @@
     <category>if97 (Water Properties)</category>
     <description>Calculates the saturated vapor speed of sound [m/s] as a function of pressure, p [Pa].</description>
   </function>
+  <!-- Below are the entries for the backwards if97 functions -->
+    <function>
+        <name>if97_tph</name>
+        <local_name>if97_tph</local_name>
+        <params>p,h</params>
+        <category>if97 (Water Properties)</category>
+        <description>Calculates the temperature, T [K], as a function of p [Pa] and mass enthalpy, h, [J/kg].</description>
+    </function>
+    <function>
+      <name>if97_tps</name>
+      <local_name>if97_tps</local_name>
+      <params>p,s</params>
+      <category>if97 (Water Properties)</category>
+      <description>Calculates the temperature, T [K], as a function of p [Pa] and mass entropy, s, [J/kg-K].</description>
+  </function>
 
 </FUNCTIONS>

--- a/wrapper/Mathcad/includes/h2bc.h
+++ b/wrapper/Mathcad/includes/h2bc.h
@@ -1,0 +1,35 @@
+// if97_h2bc stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_h2bc(P), which is a wrapper for
+// the CoolProp-IF97 function, h2bc(P), used to calculate the 
+// enthalpy along the Region 2b/2c boundary as a function of pressure
+LRESULT  if97_H2BC(
+    LPCOMPLEXSCALAR c,  // pointer to the result
+    LPCCOMPLEXSCALAR a) // pointer to the parameter received from Mathcad
+{  
+    // first check to make sure "a" has no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+
+    if ( (a->real < IF97::P2bcmin) || (a->real > IF97::Pmax) )
+        return MAKELRESULT(P_OUT_OF_RANGE,1);
+
+    //otherwise, all is well, evaluate function
+    c->real = IF97::Backwards::H2b2c_p(a->real);
+
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_h2bc = 
+{
+    "if97_h2bc",                     // name by which Mathcad will recognize the function
+    "p",                             // if97_h2bc will be called as if97_h2bc(p)
+    // description of if97_t23(p)
+    "Obtains Enthalpy [J/kg] along the Region 2b/2c boundary as a function of pressure [Pa].",
+    (LPCFUNCTION)if97_H2BC,          // pointer to executable code
+    COMPLEX_SCALAR,                  // the return type is a complex scalar
+    1,                               // there is only one input parameter
+    { COMPLEX_SCALAR }               //    it is a complex scalar
+};

--- a/wrapper/Mathcad/includes/h3ab.h
+++ b/wrapper/Mathcad/includes/h3ab.h
@@ -1,0 +1,35 @@
+// if97_h3ab stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_h3ab(P), which is a wrapper for
+// the CoolProp-IF97 function, h3ab(P), used to calculate the 
+// enthalpy along the Region 3a/3b boundary as a function of pressure
+LRESULT  if97_H3AB(
+    LPCOMPLEXSCALAR c,  // pointer to the result
+    LPCCOMPLEXSCALAR a) // pointer to the parameter received from Mathcad
+{  
+    // first check to make sure "a" has no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+
+    if ( (a->real < IF97::Pcrit) || (a->real > IF97::Pmax) )
+        return MAKELRESULT(P_OUT_OF_RANGE,1);
+
+    //otherwise, all is well, evaluate function
+    c->real = IF97::Backwards::H3ab_p(a->real);
+
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_h3ab = 
+{
+    "if97_h3ab",                     // name by which Mathcad will recognize the function
+    "p",                             // if97_h3ab will be called as if97_h3ab(p)
+    // description of if97_t23(p)
+    "Obtains Enthalpy [J/kg] along the Region 3a/3b boundary as a function of pressure [Pa].",
+    (LPCFUNCTION)if97_H3AB,          // pointer to executable code
+    COMPLEX_SCALAR,                  // the return type is a complex scalar
+    1,                               // there is only one input parameter
+    { COMPLEX_SCALAR }               //    it is a complex scalar
+};

--- a/wrapper/Mathcad/includes/pcrit.h
+++ b/wrapper/Mathcad/includes/pcrit.h
@@ -9,7 +9,7 @@ LRESULT  if97_Pcrit(
     LPCCOMPLEXSCALAR a) // pointer to the parameter received from Mathcad
 {  
     // stuff result into return scalar structure
-    c->real = Pcrit;
+    c->real = IF97::Pcrit;
 
     // normal return
     return 0;

--- a/wrapper/Mathcad/includes/ptrip.h
+++ b/wrapper/Mathcad/includes/ptrip.h
@@ -9,7 +9,7 @@ LRESULT  if97_Ptrip(
     LPCCOMPLEXSCALAR a) // pointer to the parameter received from Mathcad
 {  
     // stuff result into return scalar structure
-    c->real = Ptrip;
+    c->real = IF97::Ptrip;
 
     // normal return
     return 0;

--- a/wrapper/Mathcad/includes/regionph.h
+++ b/wrapper/Mathcad/includes/regionph.h
@@ -1,0 +1,44 @@
+// if97_regionph stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_regionph(P,h), which is a wrapper for
+// the CoolProp-IF97 test function, Region_ph(p,h).
+LRESULT  if97_REGIONPH(
+    LPCOMPLEXSCALAR c,  // pointer to the result
+    LPCCOMPLEXSCALAR a,
+    LPCCOMPLEXSCALAR b) // pointer to the parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::Region_ph(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else // (e.what == "H")
+            return MAKELRESULT(H_OUT_OF_RANGE,2);
+    }
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_regionph = 
+{
+    "if97_regionph",                 // name by which Mathcad will recognize the function
+    "p,h",                           // if97_tph will be called as if97_tph(p,h)
+    // description of if97_regionph(p)
+    "Obtains the Region Number as a function of p [Pa] and mass enthalpy, h, [J/kg].",
+    (LPCFUNCTION)if97_REGIONPH,           // pointer to executable code
+    COMPLEX_SCALAR,                  // the return type is a complex scalar
+    2,                               // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }               //    that are both complex scalars
+};

--- a/wrapper/Mathcad/includes/regionps.h
+++ b/wrapper/Mathcad/includes/regionps.h
@@ -1,0 +1,44 @@
+// if97_regionps stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_regionps(P,h), which is a wrapper for
+// the CoolProp-IF97 test function, Region_ps(p,h).
+LRESULT  if97_REGIONPS(
+    LPCOMPLEXSCALAR c,  // pointer to the result
+    LPCCOMPLEXSCALAR a,
+    LPCCOMPLEXSCALAR b) // pointer to the parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::Region_ps(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else // (e.what == "S")
+            return MAKELRESULT(S_OUT_OF_RANGE,2);
+    }
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_regionps = 
+{
+    "if97_regionps",                 // name by which Mathcad will recognize the function
+    "p,s",                           // if97_regionps will be called as if97_regionps(p,h)
+    // description of if97_regionps(p)
+    "Obtains the Region Number as a function of p [Pa] and mass entropy, s, [J/kg-K].",
+    (LPCFUNCTION)if97_REGIONPS,           // pointer to executable code
+    COMPLEX_SCALAR,                  // the return type is a complex scalar
+    2,                               // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }               //    that are both complex scalars
+};

--- a/wrapper/Mathcad/includes/t23.h
+++ b/wrapper/Mathcad/includes/t23.h
@@ -12,7 +12,7 @@ LRESULT  if97_T23(
     if ( a->imag != 0.0 )
         return MAKELRESULT(MUST_BE_REAL,1);
 
-    if ( (a->real < P23min) || (a->real > Pmax) )
+    if ( (a->real < IF97::P23min) || (a->real > IF97::Pmax) )
         return MAKELRESULT(T_OUT_OF_RANGE,1);
 
     //otherwise, all is well, evaluate function

--- a/wrapper/Mathcad/includes/tcrit.h
+++ b/wrapper/Mathcad/includes/tcrit.h
@@ -9,7 +9,7 @@ LRESULT  if97_Tcrit(
     LPCCOMPLEXSCALAR a) // pointer to the parameter received from Mathcad
 {  
     // stuff result into return scalar structure
-    c->real = Tcrit;
+    c->real = IF97::Tcrit;
 
     // normal return
     return 0;

--- a/wrapper/Mathcad/includes/tph.h
+++ b/wrapper/Mathcad/includes/tph.h
@@ -1,0 +1,44 @@
+// if97_tph stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_tph(P,h), which is a wrapper for
+// the CoolProp-IF97 function, T_phmass(p,h).
+LRESULT  if97_TPH(
+    LPCOMPLEXSCALAR c,  // pointer to the result
+    LPCCOMPLEXSCALAR a,
+    LPCCOMPLEXSCALAR b) // pointer to the parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::T_phmass(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else // (e.what == "H")
+            return MAKELRESULT(H_OUT_OF_RANGE,2);
+    }
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_tph = 
+{
+    "if97_tph",                      // name by which Mathcad will recognize the function
+    "p,h",                           // if97_tph will be called as if97_tph(p,h)
+    // description of if97_tph(p,h)
+    "Obtains the temperature, T [K], as a function of p [Pa] and mass enthalpy, h, [J/kg].",
+    (LPCFUNCTION)if97_TPH,           // pointer to executable code
+    COMPLEX_SCALAR,                  // the return type is a complex scalar
+    2,                               // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }               //    that are both complex scalars
+};

--- a/wrapper/Mathcad/includes/tps.h
+++ b/wrapper/Mathcad/includes/tps.h
@@ -1,0 +1,44 @@
+// if97_tps stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_tps(P,h), which is a wrapper for
+// the CoolProp-IF97 function, T_psmass(p,h).
+LRESULT  if97_TPS(
+    LPCOMPLEXSCALAR c,  // pointer to the result
+    LPCCOMPLEXSCALAR a,
+    LPCCOMPLEXSCALAR b) // pointer to the parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::T_psmass(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else // (e.what == "S")
+            return MAKELRESULT(S_OUT_OF_RANGE,2);
+    }
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_tps = 
+{
+    "if97_tps",                      // name by which Mathcad will recognize the function
+    "p,s",                           // if97_tps will be called as if97_tps(p,h)
+    // description of if97_tps(p,s)
+    "Obtains the temperature, T [K], as a function of p [Pa] and mass entropy, s, [J/kg-K].",
+    (LPCFUNCTION)if97_TPS,           // pointer to executable code
+    COMPLEX_SCALAR,                  // the return type is a complex scalar
+    2,                               // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }               //    that are both complex scalars
+};

--- a/wrapper/Mathcad/includes/ttrip.h
+++ b/wrapper/Mathcad/includes/ttrip.h
@@ -9,7 +9,7 @@ LRESULT  if97_Ttrip(
     LPCCOMPLEXSCALAR a) // pointer to the parameter received from Mathcad
 {  
     // stuff result into return scalar structure
-    c->real = Ttrip;
+    c->real = IF97::Ttrip;
 
     // normal return
     return 0;


### PR DESCRIPTION
- [x] Backward equations implemented as T_phmass(p,h) and T_psmass(p,s)  
- [x] Found and corrected bug in backward T23(p) boundary equation (indices not zero based)  
- [x] Added more general comments to code...  
- [x] Updated Mathcad wrapper to provide T(p,h) & T(p,s) as well as some test boundary functions  
- [x] Updated Stand-alone check program IF97.cpp to print verification tables for backward eqs.  

Verification tables from Mathcad shown below:  
![backward1](https://cloud.githubusercontent.com/assets/17114032/20489787/c39bb196-afd9-11e6-9659-3ad9f259025f.PNG)
![backward2](https://cloud.githubusercontent.com/assets/17114032/20490044/9d89124a-afda-11e6-8325-64c77169d061.PNG)
![backward3](https://cloud.githubusercontent.com/assets/17114032/20489808/d302ee10-afd9-11e6-833b-bf0e702b4e46.PNG)
![backward4](https://cloud.githubusercontent.com/assets/17114032/20489810/d4cddd5e-afd9-11e6-8eb7-d1336c444f52.PNG)
