### PR TITLE
Fix ambiguous call to abs(double) - call std::abs() instead.

### DIFF
--- a/IF97.h
+++ b/IF97.h
@@ -3977,7 +3977,7 @@ namespace IF97
         static Region2 R2;
         double T = RegionOutputBackward( p, X, inkey);
         double Tsat = Tsat97(p); 
-        if (abs(T-Tsat) < 1.0E-10){                                // If in saturation dome
+        if (std::abs(T-Tsat) < 1.0E-10){                           // If in saturation dome
             double Xliq = R1.output(inkey,Tsat,p);
             double Xvap = R2.output(inkey,Tsat,p);
             double vliq = 1.0/R1.output(IF97_DMASS,Tsat,p);


### PR DESCRIPTION
Fixed one lone abs() call in IF97.h; replaced with std::abs().

It wasn't causing an error/warning in VS2010, but was in mingw64, possibly other compilers as well.