### PR TITLE
Function rho_pX patch

### DIFF
--- a/IF97.h
+++ b/IF97.h
@@ -28,7 +28,7 @@ struct RegionResidualElement      // Structure for the double indexed state equa
 namespace IF97
 {    
     // CoolProp-IF97 Version Number
-    static char IF97VERSION [] = "v2.0.0";
+    static char IF97VERSION [] = "v2.0.1";
     // Setup Water Constants for Trivial Functions and use in Region Classes
     // Constant values from:
     // Revised Release on the IAPWS Industrial Formulation 1997
@@ -4071,9 +4071,9 @@ namespace IF97
         //       equation is needed instead of two in Region 3.
         static Region1 R1;
         static Region2 R2;
-        const double T = RegionOutputBackward( p, X, inkey);
-        const double Tsat = Tsat97(p); 
-        if (std::abs(T-Tsat) < 1.0E-10){                           // If in saturation dome
+        const double T = RegionOutputBackward( p, X, inkey); 
+        if (RegionDetermination_pX(p, X, inkey) == REGION_4){      // If in saturation dome
+            const double Tsat = Tsat97(p);
             const double Xliq = R1.output(inkey,Tsat,p);
             const double Xvap = R2.output(inkey,Tsat,p);
             const double vliq = 1.0/R1.output(IF97_DMASS,Tsat,p);

--- a/wrapper/Mathcad/IF97.cpp
+++ b/wrapper/Mathcad/IF97.cpp
@@ -118,6 +118,8 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
     #include ".\includes\tps.h"
     #include ".\includes\phs.h"
     #include ".\includes\ths.h"
+    #include ".\includes\rhoph.h"
+    #include ".\includes\rhops.h"
 
     // DLL entry point code.  the _CRT_INIT function is needed
     // if you are using Microsoft's 32 bit compiler
@@ -224,6 +226,8 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
                     CreateUserFunction( hDLL, &if97_tps );
                     CreateUserFunction( hDLL, &if97_phs );
                     CreateUserFunction( hDLL, &if97_ths );
+                    CreateUserFunction( hDLL, &if97_rhoph );
+                    CreateUserFunction( hDLL, &if97_rhops );
                     break;
                     }
 

--- a/wrapper/Mathcad/IF97.vcxproj
+++ b/wrapper/Mathcad/IF97.vcxproj
@@ -140,6 +140,8 @@
     <ClInclude Include="includes\regionps.h" />
     <ClInclude Include="includes\rhof.h" />
     <ClInclude Include="includes\rhog.h" />
+    <ClInclude Include="includes\rhoph.h" />
+    <ClInclude Include="includes\rhops.h" />
     <ClInclude Include="includes\rhotp.h" />
     <ClInclude Include="includes\sf.h" />
     <ClInclude Include="includes\sg.h" />

--- a/wrapper/Mathcad/includes/rhoph.h
+++ b/wrapper/Mathcad/includes/rhoph.h
@@ -1,0 +1,45 @@
+// if97_rhoph stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_rhoph(P), which is a wrapper for
+// the CoolProp-IF97 function, rhomass_phmass(P,H), used to calculate the density
+// in terms of pressure and enthalpy
+LRESULT  if97_RhoPH(
+    LPCOMPLEXSCALAR c,  // pointer to the result (density)
+    LPCCOMPLEXSCALAR a, // pointer to the pressure parameter received from Mathcad
+    LPCCOMPLEXSCALAR b) // pointer to the enthalpy parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::rhomass_phmass(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else // (e.what == "H")
+            return MAKELRESULT(H_OUT_OF_RANGE,2);
+    }
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_rhoph = 
+{
+    "if97_rhoph",                        // name by which Mathcad will recognize the function
+    "p,h",                               // if97_RhoPH will be called as if97_rhoph(p,h)
+    // description of if97_rhoph(p)
+    "Obtains the mass density [kg/m^3] as a function of p [Pa] and h [J/kg].",
+    (LPCFUNCTION)if97_RhoPH,             // pointer to executable code
+    COMPLEX_SCALAR,                      // the return type is a complex scalar
+    2,                                   // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }   //    that are both complex scalars
+};

--- a/wrapper/Mathcad/includes/rhops.h
+++ b/wrapper/Mathcad/includes/rhops.h
@@ -1,0 +1,45 @@
+// if97_rhops stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_rhops(P), which is a wrapper for
+// the CoolProp-IF97 function, rhomass_psmass(P,S), used to calculate the density
+// in terms of pressure and entropy
+LRESULT  if97_RhoPS(
+    LPCOMPLEXSCALAR c,  // pointer to the result (density)
+    LPCCOMPLEXSCALAR a, // pointer to the pressure parameter received from Mathcad
+    LPCCOMPLEXSCALAR b) // pointer to the entropy parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::rhomass_psmass(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else // (e.what == "H")
+            return MAKELRESULT(H_OUT_OF_RANGE,2);
+    }
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_rhops = 
+{
+    "if97_rhops",                        // name by which Mathcad will recognize the function
+    "p,s",                               // if97_RhoPS will be called as if97_rhops(p,s)
+    // description of if97_rhops(p)
+    "Obtains the mass density [kg/m^3] as a function of p [Pa] and s [J/kg-K].",
+    (LPCFUNCTION)if97_RhoPS,             // pointer to executable code
+    COMPLEX_SCALAR,                      // the return type is a complex scalar
+    2,                                   // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }   //    that are both complex scalars
+};

--- a/wrapper/Mathcad/includes/rhotp.h
+++ b/wrapper/Mathcad/includes/rhotp.h
@@ -2,12 +2,12 @@
 //
 
 // this code executes the user function if97_rhotp(P), which is a wrapper for
-// the CoolProp-IF97 function, rhomass_Tp(P), used to calculate the saturation
-// temperature along the saturation curve in terms of pressure
+// the CoolProp-IF97 function, rhomass_Tp(P), used to calculate the density
+// at the temperature and pressure state point
 LRESULT  if97_RhoTP(
     LPCOMPLEXSCALAR c,  // pointer to the result
-    LPCCOMPLEXSCALAR a,
-    LPCCOMPLEXSCALAR b) // pointer to the parameter received from Mathcad
+    LPCCOMPLEXSCALAR a, // pointer to the temperature parameter received from Mathcad
+    LPCCOMPLEXSCALAR b) // pointer to the pressure parameter received from Mathcad
 {  
     // first check to make sure "a" and "b" have no imaginary component
     if ( a->imag != 0.0 )

--- a/wrapper/Mathcad/includes/vtp.h
+++ b/wrapper/Mathcad/includes/vtp.h
@@ -2,12 +2,12 @@
 //
 
 // this code executes the user function if97_vtp(P), which is a wrapper for
-// the CoolProp-IF97 function, Tsat97(P), used to calculate the saturation
-// temperature along the saturation curve in terms of pressure
+// the CoolProp-IF97 function, Tsat97(P), used to calculate the specific
+// volume at the temperature and pressure state point
 LRESULT  if97_VTP(
     LPCOMPLEXSCALAR c,  // pointer to the result
-    LPCCOMPLEXSCALAR a,
-    LPCCOMPLEXSCALAR b) // pointer to the parameter received from Mathcad
+    LPCCOMPLEXSCALAR a, // pointer to the temperature parameter received from Mathcad
+    LPCCOMPLEXSCALAR b) // pointer to the pressure parameter received from Mathcad
 {  
     // first check to make sure "a" and "b" have no imaginary component
     if ( a->imag != 0.0 )


### PR DESCRIPTION
Patched function rho_pX including:
- return missing on one logic branch
- fixed vapor/liquid logic ( code was copied incorrectly )
- updated logic to determine if in vapor dome
- Added Mathcad stubs for rhops(p,s) and rhoph(p,h) for testing

Patch tested for Enthalpy and Entropy in Regions 1-3 and Region 4.  ( closes #16 )