### PR TITLE
Saturation Functions Patch

### DIFF
--- a/IF97.h
+++ b/IF97.h
@@ -3927,12 +3927,13 @@ namespace IF97
                            break;
             case REGION_3: return R3.output(outkey, T, p, State);
                            break;
-            case REGION_4: if (State == VAPOR)
+            case REGION_4: if (State == VAPOR) {
                                return R2.output(outkey, T, p);
-                           else if (State == LIQUID)
+                           } else if (State == LIQUID) {
                                return R1.output(outkey, T, p);
-                           else
+                           } else {
                                throw std::out_of_range("Cannot use Region 4 with T and p as inputs");
+                           }
                            break;
             case REGION_5: return R5.output(outkey, T, p);
         }

--- a/IF97.h
+++ b/IF97.h
@@ -3919,12 +3919,21 @@ namespace IF97
                                return R2.output(outkey, T, p);  // On saturation curve and need the Vapor phase
                            else
                                return R1.output(outkey, T, p);  // otherwise, use Liquid Region 1
+                           break;
             case REGION_2: if (State == LIQUID)
                                return R1.output(outkey, T, p);  // On saturation curve and need the Liquid phase
                            else
                                return R2.output(outkey, T, p);  // otherwise, use Vapor Region 2
+                           break;
             case REGION_3: return R3.output(outkey, T, p, State);
-            case REGION_4: throw std::invalid_argument("Cannot use Region 4 with T and p as inputs");
+                           break;
+            case REGION_4: if (State == VAPOR)
+                               return R2.output(outkey, T, p);
+                           else if (State == LIQUID)
+                               return R1.output(outkey, T, p);
+                           else
+                               throw std::out_of_range("Cannot use Region 4 with T and p as inputs");
+                           break;
             case REGION_5: return R5.output(outkey, T, p);
         }
         throw std::out_of_range("Unable to match region");

--- a/wrapper/Mathcad/IF97.cpp
+++ b/wrapper/Mathcad/IF97.cpp
@@ -23,7 +23,7 @@ enum { MC_STRING = STRING };  // substitute enumeration variable MC_STRING for S
 
 // Mathcad Error Codes
 enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_OUT_OF_RANGE, SATURATED, NO_SOLUTION_FOUND, 
-          D_OUT_OF_RANGE, H_OUT_OF_RANGE, S_OUT_OF_RANGE, REGION_NOT_FOUND, NUMBER_OF_ERRORS};
+          D_OUT_OF_RANGE, H_OUT_OF_RANGE, S_OUT_OF_RANGE, REGION_NOT_FOUND, UNKNOWN, NUMBER_OF_ERRORS};
 
     // Table of Error Messages
     // These message strings MUST be in the order of the Error Code enumeration above, with the last being a dummy value for error count
@@ -40,6 +40,7 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
         "Enthalpy out of Range",
         "Entropy out of Range",
         "Region not found",
+        "Exception thrown - Error Unknown",
         "Error Count - Not Used"
     };
 

--- a/wrapper/Mathcad/includes/cptp.h
+++ b/wrapper/Mathcad/includes/cptp.h
@@ -21,8 +21,12 @@ LRESULT  if97_CpTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/cvtp.h
+++ b/wrapper/Mathcad/includes/cvtp.h
@@ -21,8 +21,12 @@ LRESULT  if97_CvTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/htp.h
+++ b/wrapper/Mathcad/includes/htp.h
@@ -21,8 +21,12 @@ LRESULT  if97_HTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/ktp.h
+++ b/wrapper/Mathcad/includes/ktp.h
@@ -21,8 +21,12 @@ LRESULT  if97_KTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/mutp.h
+++ b/wrapper/Mathcad/includes/mutp.h
@@ -21,8 +21,12 @@ LRESULT  if97_MUTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/prtp.h
+++ b/wrapper/Mathcad/includes/prtp.h
@@ -21,8 +21,12 @@ LRESULT  if97_PRTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/rhotp.h
+++ b/wrapper/Mathcad/includes/rhotp.h
@@ -22,8 +22,12 @@ LRESULT  if97_RhoTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/stp.h
+++ b/wrapper/Mathcad/includes/stp.h
@@ -21,8 +21,12 @@ LRESULT  if97_STP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/utp.h
+++ b/wrapper/Mathcad/includes/utp.h
@@ -21,8 +21,12 @@ LRESULT  if97_UTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/vtp.h
+++ b/wrapper/Mathcad/includes/vtp.h
@@ -22,8 +22,12 @@ LRESULT  if97_VTP(
     catch (const std::out_of_range &e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error& ) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);

--- a/wrapper/Mathcad/includes/wtp.h
+++ b/wrapper/Mathcad/includes/wtp.h
@@ -21,8 +21,12 @@ LRESULT  if97_WTP(
     catch (const std::out_of_range& e) { 
         if (e.what()[0] == 'T') 
             return MAKELRESULT(T_OUT_OF_RANGE,1);
-        else // (e.what == "P")
+        else if (e.what()[0] == 'P')
             return MAKELRESULT(P_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'C')
+            return MAKELRESULT(SATURATED,1);
+        else
+            return MAKELRESULT(UNKNOWN,1);
     }
     catch (const std::logic_error&) {
         return MAKELRESULT(NO_SOLUTION_FOUND,1);


### PR DESCRIPTION
Patch RegionOutput() to correctly handle detection of Region 4 when provided (T, p) state point on the saturation curve from a saturation function that provides the desired vapor/liquid state.  Closes #19.   

In addition:
- [x] Exception for non-saturation function on saturation curve changed to "out_of_range".
- [x] Mathcad wrapper catches a "saturated" condition correctly in all TP wrapper functions.
- [x] Additional error flag in Mathcad wrapper added for "UNKNOWN" exception thrown.

Tested in MinGW and VS compilers for correct behavior of saturation functions.