### PR TITLE
[cmake] add standard IF97 targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,21 @@ set(project_name "IF97")
 set(app_name ${project_name})
 project(${project_name})
 
-SET(CMAKE_BUILD_TYPE Release)
+if(IF97_BUILD_TARGETS)
+    add_library(IF97 IF97.cpp)
+
+    install(TARGETS IF97
+	RUNTIME DESTINATION bin
+	ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION lib
+    )
+    
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        install(FILES IF97.h DESTINATION include)
+    endif()
+else()
+    SET(CMAKE_BUILD_TYPE Release)
+endif()
 
 #########################################################################
 #                              WRAPPER MODULES                          #


### PR DESCRIPTION
Including this in the CMake file will allow this to be easily built with vcpkg.