### PR TITLE
Feature/packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ set(project_name "IF97")
 set(app_name ${project_name})
 project(${project_name})
 
-SET(CMAKE_BUILD_TYPE Release)
-
 #########################################################################
 #                              WRAPPER MODULES                          #
 #-----------------------------------------------------------------------#
@@ -30,8 +28,9 @@ SET(CMAKE_BUILD_TYPE Release)
 #########################
 #  MATHCAD PRIME MODULE #
 #########################
-	
+option(IF97_PRIME_MODULE "Build MathCAD Prime wrapper" OFF)
 if (IF97_PRIME_MODULE)
+    set(CMAKE_BUILD_TYPE Release CACHE)
     set(IF97_FLAG ON)
     if(NOT WIN32)
       message(FATAL_ERROR "IF97_PRIME_MODULE can only be used on windows host")
@@ -41,7 +40,7 @@ if (IF97_PRIME_MODULE)
     else()
         message(STATUS "IF97_PRIME_ROOT: ${IF97_PRIME_ROOT}")
     endif()
-	FILE(GLOB_RECURSE IF97_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/Mathcad/includes/*.h")
+    FILE(GLOB_RECURSE IF97_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/Mathcad/includes/*.h")
     include_directories("${IF97_PRIME_ROOT}/Custom Functions" "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/Mathcad/includes")
     add_library(IF97 SHARED ${IF97_HEADERS} "${CMAKE_CURRENT_SOURCE_DIR}/IF97.h" "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/MathCAD/IF97.cpp")
     target_link_libraries(IF97 "${IF97_PRIME_ROOT}/Custom Functions/mcaduser.lib")
@@ -54,8 +53,9 @@ endif()
 #########################
 #   MATHCAD 15 MODULE   #
 #########################
-
+option(IF97_MATHCAD15_MODULE "Build MathCAD 15 wrapper" OFF)
 if (IF97_MATHCAD15_MODULE)
+    set(CMAKE_BUILD_TYPE Release CACHE)
     set(IF97_FLAG ON)
     if(NOT WIN32)
       message(FATAL_ERROR "IF97_MATHCAD15_MODULE can only be used on windows host")
@@ -65,7 +65,7 @@ if (IF97_MATHCAD15_MODULE)
     else()
         message(STATUS "IF97_MATHCAD15_ROOT: ${IF97_MATHCAD15_ROOT}")
     endif()
-	FILE(GLOB_RECURSE IF97_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/Mathcad/includes/*.h")
+    FILE(GLOB_RECURSE IF97_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/Mathcad/includes/*.h")
     include_directories("${IF97_MATHCAD15_ROOT}/userefi/microsft/include" "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/Mathcad/includes")
     add_library(IF97 SHARED ${IF97_HEADERS} "${CMAKE_CURRENT_SOURCE_DIR}/IF97.h" "${CMAKE_CURRENT_SOURCE_DIR}/wrapper/MathCAD/IF97.cpp")
     target_link_libraries(IF97 "${IF97_MATHCAD15_ROOT}/userefi/microsft/lib/mcaduser.lib")
@@ -76,12 +76,34 @@ if (IF97_MATHCAD15_MODULE)
  #   install (FILES "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/if97_EN.xml" DESTINATION MathCAD15)
 endif()
 
+###########################
+# CMAKE INTERFACE LIBRARY #
+###########################
+option(IF97_CMAKE_MODULE "Build CMake interface library" OFF)
+if(IF97_CMAKE_MODULE)
+    set(CMAKE_BUILD_TYPE Release CACHE)
+    set(IF97_FLAG ON)
+    message(STATUS "Building IF97 CMake interface library")
+    #add_library(IF97 STATIC "${CMAKE_CURRENT_SOURCE_DIR}/IF97.h")
+    #set_target_properties(IF97 PROPERTIES LINKER_LANGUAGE CXX)
+    add_library(IF97 INTERFACE)
+    #target_include_directories(IF97 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_include_directories(IF97 INTERFACE  
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/IF97>  
+        $<INSTALL_INTERFACE:include/IF97>  # <prefix>/include/IF97
+    )
+    install(
+        FILES IF97.h
+        DESTINATION "include"
+    )
+endif()
+
 #########################
 # TEST MODULE (DEFAULT) #
 #########################
-
+option(IF97_FLAG "Skip IF97 test executable" OFF)
 if (NOT IF97_FLAG)
     message(STATUS "Stand-alone IF97 Test.")
-	add_executable(IF97 "${CMAKE_CURRENT_SOURCE_DIR}/IF97.cpp")
+    add_executable(IF97 "${CMAKE_CURRENT_SOURCE_DIR}/IF97.cpp")
 endif()
 

--- a/IF97.h
+++ b/IF97.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cmath>
+#include <algorithm>
 #include <iostream>
 #include <iomanip>      // std::setprecision
 #include <stdexcept>
@@ -29,7 +30,7 @@ struct RegionResidualElement      // Structure for the double indexed state equa
 namespace IF97
 {    
     // CoolProp-IF97 Version Number
-    static char IF97VERSION [] = "v2.1.0";
+    static char IF97VERSION [] = "v2.1.1";
     // Setup Water Constants for Trivial Functions and use in Region Classes
     // Constant values from:
     // Revised Release on the IAPWS Industrial Formulation 1997

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Almost all of the other implementations of IF97 are not free and closed-source. 
 Try it
 ------
 
-Build the cmake project doing something like 
+Build the stand-alone CMake project doing something like 
     
 ```
 mkdir build
@@ -28,6 +28,16 @@ cmake --build .
 ```
 
 This will spit out the values for the computer-program verification, they should agree with the values from http://www.iapws.org/relguide/IF97-Rev.pdf and other IAPWS documents as noted in the output.  In Region 3, the backwards equations are used, which results in some loss of precision, but it is usually less than 0.001%.  
+
+Accessing IF97 from your software
+---------------------------------
+
+There is a `wrappers` directory for 3rd party applications, including:
+- Mathcad 15 (Jeff Henning main contributor, use with `cmake .. -DIF97_MATHCAD15_MODULE=ON`)
+- Mathcad Prime (Jeff Henning main contributor, use with `cmake .. -DIF97_PRIME_MODULE=ON`)
+
+Furthermore, there is an interface library target that installs the header file. This target can also be digested by other CMake-based projects using the `add_subdirectory` command. Enable it with the CMake option `cmake .. -DIF97_CMAKE_MODULE=ON`.
+
 
 Compiler Switches
 -----------------
@@ -71,9 +81,3 @@ MIT-style license (see LICENSE)
 Basically, you can do anything you like with the code.  The MIT license is a very permissive license, allowing you to modify, distribute, sell, etc. the code.  It is *not* a copy-left license, you can use this in commercial code.  
 
 You are strongly requested, but not required, to cite both this repository and that of CoolProp: www.coolprop.org  
-
-Wrappers
---------
-
-Wrappers directory for 3rd Party Apps, including:
-- Mathcad 15 and Prime (Jeff Henning main contributor)  


### PR DESCRIPTION
Added algorithm and bumped version number, turned build switches into options, added a standard interface library target `IF97_CMAKE_MODULE` that includes an install target, should replace #24 and #25 