### PR TITLE
Reverse T(P,H) patch

### DIFF
--- a/IF97.h
+++ b/IF97.h
@@ -37,6 +37,11 @@ namespace IF97
     //     for the Thermodynamic Properties of Water and Steam, August 2007
     // IAPWS G5-01(2016), Guideline on the Use of Fundamental Physical Constants
     //      and Basic Constants of Water
+    // * IAPWS constants use units of MPa and kJ and are entered as such, but converted as needed to SI
+    //         depending on the definition of IAPWS_UNITS below.  Main program can define IAPWS_UNITS
+    //         to leave all input/output values in IAPWS units, which is handy for results verification
+    //         against values printed in the IAPWS documents.  CoolProp will never use this definition.
+    //         Converted constants below are commented with an *.
 #ifdef IAPWS_UNITS
     const double p_fact  = 1.0;                 // Leaves Thermodynamic Properties in IAPWS units of MPa
     const double R_fact  = 1.0;                 // Leaves Thermodynamic Properties in IAPWS units of kJ
@@ -46,41 +51,41 @@ namespace IF97
 #endif
     // IF97 Constants
     const double Tcrit   = 647.096;             // K
-    const double Pcrit   = 22.064*p_fact;       // Pa
+    const double Pcrit   = 22.064*p_fact;       // MPa*
     const double Rhocrit = 322.0;               // kg/m³
-    const double Scrit   = 4.41202148223476*R_fact; // J/kg-K (needed for backward eqn. in Region 3(a)(b)
+    const double Scrit   = 4.41202148223476*R_fact; // kJ*/kg-K (needed for backward eqn. in Region 3(a)(b)
     const double Ttrip   = 273.16;              // K
-    const double Ptrip   = 0.000611656*p_fact;  // Pa
+    const double Ptrip   = 0.000611656*p_fact;  // MPa*
     const double Tmin    = 273.15;              // K
     const double Tmax    = 1073.15;             // K
-    const double Pmin    = 0.000611213*p_fact;  // Pa
-    const double Pmax    = 100.0*p_fact;        // Pa
-    const double Rgas    = 0.461526*R_fact;     // J/kg-K : mass based!
+    const double Pmin    = 0.000611213*p_fact;  // MPa*
+    const double Pmax    = 100.0*p_fact;        // MPa*
+    const double Rgas    = 0.461526*R_fact;     // kJ*/kg-K : mass based!
     const double MW      = 0.018015268;         // kg/mol
     // Bounds for Region Determination
     const double Text    = 2273.15;             // Extended (Region 5) Temperature Limit (Region 5) [K]
-    const double Pext    = 50.0*p_fact;         // Extended (Region 5) Pressure Limit (Region 5) [Pa]
-    const double P23min  = 16.529164252605*p_fact; // Min Pressure on Region23 boundary curve; Max is Pmax
+    const double Pext    = 50.0*p_fact;         // Extended (Region 5) Pressure Limit (Region 5) [MPa*]
+    const double P23min  = 16.529164252605*p_fact; // Min Pressure [MPa*] on Region23 boundary curve; Max is Pmax
     const double T23min  = 623.15;              // Min Temperature on Region23 boundary curve
     const double T23max  = 863.15;              // Max Temperature on Region23 boundary curve
-    const double P2amax  = 4.0*p_fact;          // Max Pressure on upper H2a2b boundary (straight line)
-    const double P2bcmin = 6.54670*p_fact;      // Min Pressure [MPa] on H2b2c boundary curve; Max is Pmax
-    const double S2bc    = 5.85*R_fact;         // Min Pressure [MPa] on H2b2c boundary curve; Max is Pmax
+    const double P2amax  = 4.0*p_fact;          // Max Pressure [MPa*] on upper H2a2b boundary (straight line)
+    const double P2bcmin = 6.54670*p_fact;      // Min Pressure [MPa*] on H2b2c boundary curve; Max is Pmax
+    const double S2bc    = 5.85*R_fact;         // Min Pressure [MPa*] on H2b2c boundary curve; Max is Pmax
     // Bounds for Backward p(h,s), t(h,s) Determination
-    const double Smin    = 0.0;                         // Min Entropy [kJ/kg-K] for Backward p(h,s)
-    const double Smax    = 11.921054825051103*R_fact;   // Max Entropy [kJ/kg-K] for Backward p(h,s)
-    const double STPmax  = 6.04048367171238*R_fact;     // S(Tmax,Pmax)
-    const double Sgtrip  = 9.155492076509681*R_fact;    // Sat. Vapor  Entropy [kJ/kg-K] at Triple Point
-    const double Sftrip  = -4.09187776773977E-7*R_fact; // Sat. Liquid Entropy [kJ/kg-K] at Triple Point
-    const double Hgtrip  = 2500.9109532932*R_fact;      // Sat. Vapor  Enthalpy [kJ/kg] at Triple Point
-    const double Hftrip  = 5.16837786577998E-4*R_fact;  // Sat. Liquid Enthalpy [kJ/kg] at Triple Point
-    const double SfT23   = 3.778281340*R_fact;          // Sat. Liquid Entropy [KJ/kg-K] at T23min
-    const double SgT23   = 5.210887825*R_fact;          // Sat. Vapor  Entropy [KJ/kg-K] at T23min
-    const double S13min  = 3.397782955*R_fact;          // Entropy at (T13,Pmax)
-    const double S23min  = 5.048096828*R_fact;          // B23 Bounding Box
-    const double S23max  = 5.260578707*R_fact;          // B23 Bounding Box
-    const double H23min  = 2.563592004E3*R_fact;        // B23 Bounding Box
-    const double H23max  = 2.812942061E3*R_fact;        // B23 Bounding Box
+    const double Smin    = 0.0;                         // Min Entropy [kJ*/kg-K] for Backward p(h,s)
+    const double Smax    = 11.921054825051103*R_fact;   // Max Entropy [kJ*/kg-K] for Backward p(h,s)
+    const double STPmax  = 6.04048367171238*R_fact;     // S(Tmax,Pmax) [kJ*/kg-K]
+    const double Sgtrip  = 9.155492076509681*R_fact;    // Sat. Vapor  Entropy [kJ*/kg-K] at Triple Point
+    const double Sftrip  = -4.09187776773977E-7*R_fact; // Sat. Liquid Entropy [kJ*/kg-K] at Triple Point
+    const double Hgtrip  = 2500.9109532932*R_fact;      // Sat. Vapor  Enthalpy [kJ*/kg] at Triple Point
+    const double Hftrip  = 5.16837786577998E-4*R_fact;  // Sat. Liquid Enthalpy [kJ*/kg] at Triple Point
+    const double SfT23   = 3.778281340*R_fact;          // Sat. Liquid Entropy [KJ*/kg-K] at T23min
+    const double SgT23   = 5.210887825*R_fact;          // Sat. Vapor  Entropy [KJ*/kg-K] at T23min
+    const double S13min  = 3.397782955*R_fact;          // Entropy at (T13,Pmax) [kJ*/kg-K]
+    const double S23min  = 5.048096828*R_fact;          // B23 Bounding Box [kJ*/kg-K]
+    const double S23max  = 5.260578707*R_fact;          // B23 Bounding Box [kJ*/kg-K]
+    const double H23min  = 2.563592004E3*R_fact;        // B23 Bounding Box [kJ*/kg-K]
+    const double H23max  = 2.812942061E3*R_fact;        // B23 Bounding Box [kJ*/kg-K]
     //
     double Tsat97(double p);  // Forward declaration of Tsat97 required for calls below.
     double psat97(double T);  // Forward declaration of psat97 required for calls below.

--- a/wrapper/Mathcad/README.rst
+++ b/wrapper/Mathcad/README.rst
@@ -1,20 +1,20 @@
-Wrapper of IF97 for MathCAD 15 and Mathcad Prime
+Wrapper of IF97 for PTC Mathcad Prime (and Legacy Mathcad)
 ================================================
 
-This wrapper will provide User Defined (Custom) Functions in Mathcad 15 (or Prime) that provide thermodynamic and transport properties for water/steam at specified state points based on the IAPWS Industrial Formulation for the Properties of Water and Steam.  While these properties can also be accessed through the CoolProp add-in, this wrapper provides **_only_** these properties without the overhead of CoolProp.
+This wrapper will provide Custom Functions (User Defined) in Mathcad Prime (or Legacy Mathcad) that provide thermodynamic and transport properties for water/steam at specified state points based on the 1997 IAPWS Industrial Formulation for the Properties of Water and Steam.  While these properties can also be accessed through the CoolProp add-in, this wrapper provides **_only_** these steam/water properties without the overhead of CoolProp.
 
-This wrapper been developed and tested on Mathcad 15.0 (any maintenance release) and Mathcad Prime 3.0/3.1.  It May work on earlier versions of Mathcad and Mathcad Prime, but it has not been tested there.
+This wrapper been developed and tested on Mathcad Prime 3.0 through 7.0 and Legacy Mathcad 15.0 (any maintenance release).  It **_may_** work on earlier versions of Mathcad and Mathcad Prime, but it has not been tested there.
 
 ------
 
-To Use
+To Use (Overview)
 ======
 
 * Build the Add-in DLL in VS2008 or later using the build instructions below.
 
-* Install the Add-in files by copying them to the appropriate Mathcad 15/Prime Installation directories.  
+* Install the Add-in files by copying them to the appropriate Mathcad Prime (or Legacy Mathcad) Installation directories as indicated below.  
 
-* View ``if97_verification.xmcdz`` or ``if97_verification.pdf`` for examples of using the functions.
+* View ``if97_verification.pdf`` or ``if97_verification_IAPWS.pdf`` for examples of using the functions.
 
 ------
 
@@ -26,7 +26,7 @@ Follow the build procedures below to ceate the IF97 add-in DLL files for either 
 Pre-Requisites
 --------------
 
-* You will need to have at least Visual Studio 2008 installed (Express version is fine).  Alternatively newer versions of Microsoft Visual Studio C++ should be fine; Builds have be tested on Visual Studio 2010 and 2015.
+* You will need to have at least Visual Studio 2008 installed (Express version is fine).  Alternatively newer versions of Microsoft Visual Studio C++ should be fine; Builds have be tested on Visual Studio 2010, 2015, 2017, and 2019.
 * You will need CMake version 2.8.12 or later from https://cmake.org/download/
 * You will need to install Git-SCM for Windows.  You can install this from https://git-for-windows.github.io
 
@@ -43,7 +43,25 @@ Download the IF97 Repository
 
     cd IF97
 
-Make the Build for Mathcad 15
+Make the Build for Mathcad Prime (any version above 3.0)
+--------------------------------
+
+* Go to the top level IF97 directory and make a build directory (something like \buildPrime)::
+
+    mkdir buildPrime
+    cd buildPrime
+
+* Build the makefile using CMake (Note: Mathcad Prime is 64-bit)::
+
+    cmake .. -DIF97_PRIME_MODULE=ON 
+             -DIF97_PRIME_ROOT="C:/Program Files/PTC/Mathcad 7.0.0.0"  
+             -G "Visual Studio 14 2015 Win64" 
+             -DCMAKE_VERBOSE_MAKEFILE=ON 
+	     
+	     (Insert your version of Visual Studio for the -G option.)
+	     (Note that Prime is 64-bit and requires the Win64 switch on this command)
+
+Make the Build for Legacy Mathcad 15 (Discontinued by PTC)
 -----------------------------
 
 * Go to the top level IF97 directory and make a build directory (something like \build15)::
@@ -55,33 +73,15 @@ Make the Build for Mathcad 15
 
     cmake .. -DIF97_MATHCAD15_MODULE=ON 
              -DIF97_MATHCAD15_ROOT="C:/Program Files (x86)/Mathcad/Mathcad 15"  
-             -G "Visual Studio 10 2010" 
+             -G "Visual Studio 14 2015" 
              -DCMAKE_VERBOSE_MAKEFILE=ON 
 	     
 	     (Insert your version of Visual Studio for the -G option.)
-
-Make the Build for Mathcad Prime
---------------------------------
-
-* Go to the top level IF97 directory and make a build directory (something like \buildPrime)::
-
-    mkdir buildPrime
-    cd buildPrime
-
-* Build the makefile using CMake (Note: Mathcad Prime is 64-bit)::
-
-    cmake .. -DIF97_PRIME_MODULE=ON 
-             -DIF97_PRIME_ROOT="C:/Program Files (x86)/Mathcad/Mathcad 15"  
-             -G "Visual Studio 10 2010 -Win64" 
-             -DCMAKE_VERBOSE_MAKEFILE=ON 
-	     
-	     (Insert your version of Visual Studio for the -G option.)
-	     (Note that Prime is 64-bit and requires the -Win64 switch on this command)
 
 Build the Project
 -----------------
 
-* Open the resulting IF97.sln file in Visual Studio and build the IF97 project, making sure that ``Release`` configuration is selected and the  the configuration and platform.  Alternatively, you can make the dynamic library (DLL) from the command line::
+* Open the resulting IF97.sln file in Visual Studio and build the IF97 project, making sure that ``Release`` configuration is selected in the VS menu toolbar and that the platform is set to ``x64`` for use with Mathcad Prime (64-bit).  Alternatively, you can build the dynamic library (DLL) from the command line using cmake::
 
     cmake --build . --config Release
   
@@ -92,17 +92,17 @@ Installing
 
 * Build the IF97 DLL as indicated above and then copy the wrapper files to the appropriate Mathcad 15 or Prime directories as follows.
 
-Mathcad 15
+Mathcad Prime (v3.0 or higher)
+----------
+* Copy the ``Release\IF97.dll`` file to ``C:\Program Files\PTC\Mathcad Prime 7.0.0.0\Custom Functions`` or equivalent for your version of Mathcad Prime.
+  
+Legacy Mathcad 15 (Discontinued)
 ----------
 * Copy the ``Release\IF97.dll`` file to ``C:\Program Files (x86)\Mathcad\Mathcad 15\userefi`` or equivalent for your version of Mathcad.    
-* **Mathcad 15 Only:** Copy the ``IF97_EN.xml`` to ``C:\Program Files (x86)\Mathcad\Mathcad 15\doc\funcdoc``.  Functions and descriptions will then be available in the Mathcad 15 interface under Insert|Function or the Functions button on the toolbar.
+* **Legacy Mathcad Only:** Copy the ``IF97_EN.xml`` to ``C:\Program Files (x86)\Mathcad\Mathcad 15\doc\funcdoc``.  Functions and descriptions will then be available in the Mathcad 15 interface under Insert|Function or the Functions button on the toolbar.  This functionality is **_still_** not available in Mathcad Prime as of version 8.0.
 
-Mathcad Prime
-----------
-* Copy the ``Release\IF97.dll`` file to ``C:\Program Files\PTC\Mathcad Prime 3.1\Custom Functions`` or equivalent for your version of Mathcad Prime.
-  
 ------
   
 Compiler Flags
 ==============
-The Mathcad wrapper code uses the ``REGION3_ITERATE`` flag to provide more accurate (but slightly slower) calculation of density in Region 3 (mostly super-critical) and does not use the ``IAPWS_UNITS`` flag, leaving all input/output values in SI units.
+The Mathcad wrapper code uses the ``REGION3_ITERATE`` flag to provide more accurate (but slightly slower) calculation of density in Region 3 (mostly super-critical), but does **_not_** use the ``IAPWS_UNITS`` flag, leaving all input/output values in SI units.


### PR DESCRIPTION
Primarily a page to fix a sub-region determination bug (closes #35) when calling reverse T(P,H) in Region 2 (super-heated vapor) between pressures of 4 MPa and ~4.5 MPa.

Also includes two additional commits that

- Update the Mathcad wrapper README file, reflecting Mathcad 15 as discontinued by PTC
- Update the comments in IF97.h to clarify IAPWS units on constant definitions
- Updated to patch release version 2.1.3

Patch verification through Mathcad in attached PDF: 
[Region 2b2c Issue Patch 2.1.3.pdf](https://github.com/CoolProp/IF97/files/8547419/Region.2b2c.Issue.Patch.2.1.3.pdf)

Verified all IAPWS T(P,H) verification points are still valid:
 
![IAPWS Reverse Validation](https://user-images.githubusercontent.com/17114032/164910880-0ebe464b-17d4-49de-8e5a-1135e81e1d44.png)

