### PR TITLE
Improve Reverse Functions Robustness Very Near Saturation

### DIFF
--- a/wrapper/Mathcad/IF97.cpp
+++ b/wrapper/Mathcad/IF97.cpp
@@ -123,6 +123,8 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
     #include "ths.h"
     #include "rhoph.h"
     #include "rhops.h"
+    #include "hps.h"
+    #include "sph.h"
     // *************************************************************
     // Quality Functions
     // *************************************************************
@@ -248,6 +250,8 @@ enum EC  {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED, T_OUT_OF_RANGE, P_
                     CreateUserFunction( hDLL, &if97_ths );
                     CreateUserFunction( hDLL, &if97_rhoph );
                     CreateUserFunction( hDLL, &if97_rhops );
+                    CreateUserFunction( hDLL, &if97_hps );
+                    CreateUserFunction( hDLL, &if97_sph );
                     // *************************************************************
                     // Quality functions
                     // *************************************************************

--- a/wrapper/Mathcad/README.md
+++ b/wrapper/Mathcad/README.md
@@ -59,7 +59,7 @@ Make the Build for Mathcad Prime (any version above 3.0)
              -DCMAKE_VERBOSE_MAKEFILE=ON 
 	     
 	> Insert your version of Visual Studio for the -G option.  
-	> Note that Mathcad Prime is 64-bit and requires the `-A x64` switch on this command
+	> Note that Mathcad Prime is 64-bit and requires the `-A x64` switch on this command.  
     > Prior to VS 2017, use something like: `-G "Visual Studio 14 2015 Win64`
 
 Make the Build for Legacy Mathcad 15 (Discontinued by PTC)

--- a/wrapper/Mathcad/includes/hps.h
+++ b/wrapper/Mathcad/includes/hps.h
@@ -1,0 +1,56 @@
+// if97_hps stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_hps(P,S), which is a wrapper for
+// the CoolProp-IF97 function, hmass_psmass(P,S), used to calculate the density
+// in terms of pressure and entropy
+LRESULT  if97_HPS(
+    LPCOMPLEXSCALAR c,  // pointer to the result (density)
+    LPCCOMPLEXSCALAR a, // pointer to the pressure parameter received from Mathcad
+    LPCCOMPLEXSCALAR b) // pointer to the entropy parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::hmass_psmass(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else if (e.what()[0] == 'T')  // (e.what == "Temperature")
+            return MAKELRESULT(T_OUT_OF_RANGE, 2);
+        else if (e.what()[0] == 'E')  // (e.what == "Ent")
+        {
+            if (e.what()[3] == 'h')       // (e.what == "Enthalpy")
+                return MAKELRESULT(H_OUT_OF_RANGE, 2);
+            else if (e.what()[3] == 'r') // (e.what == 'Entropy')
+                return MAKELRESULT(S_OUT_OF_RANGE, 2);
+            else
+                return MAKELRESULT(UNKNOWN, 2);
+        }
+        else
+            return MAKELRESULT(UNKNOWN, 2);
+    }
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_hps = 
+{
+    "if97_hps",                          // name by which Mathcad will recognize the function
+    "p,s",                               // if97_HPS will be called as if97_hps(p,s)
+    // description of if97_rhops(p)
+    "Obtains the enthalpy [kJ/kg] as a function of p [Pa] and entropy, s [J/kg-K].",
+    (LPCFUNCTION)if97_HPS,               // pointer to executable code
+    COMPLEX_SCALAR,                      // the return type is a complex scalar
+    2,                                   // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }   //    that are both complex scalars
+};

--- a/wrapper/Mathcad/includes/sph.h
+++ b/wrapper/Mathcad/includes/sph.h
@@ -1,0 +1,56 @@
+// if97_sph stub - Interfaces CoolProp IF97 function to Mathcad
+//
+
+// this code executes the user function if97_sph(P,S), which is a wrapper for
+// the CoolProp-IF97 function, hmass_psmass(P,S), used to calculate the density
+// in terms of pressure and entropy
+LRESULT  if97_SPH(
+    LPCOMPLEXSCALAR c,  // pointer to the result (density)
+    LPCCOMPLEXSCALAR a, // pointer to the pressure parameter received from Mathcad
+    LPCCOMPLEXSCALAR b) // pointer to the entropy parameter received from Mathcad
+{  
+    // first check to make sure "a" and "b" have no imaginary component
+    if ( a->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,1);
+    if ( b->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+
+    //otherwise, all is well, evaluate function
+    try {
+        c->real = IF97::smass_phmass(a->real,b->real);
+    }
+    catch (const std::out_of_range& e) { 
+        if (e.what()[0] == 'P') 
+            return MAKELRESULT(P_OUT_OF_RANGE,1);
+        else if (e.what()[0] == 'T')  // (e.what == "Temperature")
+            return MAKELRESULT(T_OUT_OF_RANGE,2);
+        else if (e.what()[0] == 'E')  // (e.what == "Ent")
+        {
+            if (e.what()[3] == 'h')       // (e.what == "Enthalpy")
+                return MAKELRESULT(H_OUT_OF_RANGE, 2);
+            else if (e.what()[3] == 'r') // (e.what == 'Entropy')
+                return MAKELRESULT(S_OUT_OF_RANGE, 2);
+            else
+                return MAKELRESULT(UNKNOWN, 2);
+        }
+        else
+            return MAKELRESULT(UNKNOWN, 2);
+    } 
+    catch (const std::logic_error&) {
+        return MAKELRESULT(NO_SOLUTION_FOUND,1);
+    }
+    // normal return
+    return 0;
+}
+
+FUNCTIONINFO    if97_sph = 
+{
+    "if97_sph",                          // name by which Mathcad will recognize the function
+    "p,h",                               // if97_SPH will be called as if97_sph(p,s)
+    // description of if97_sph(p)
+    "Obtains the entropy [J/kg-K] as a function of p [Pa] and enthalpy, h [kJ/kg].",
+    (LPCFUNCTION)if97_SPH,               // pointer to executable code
+    COMPLEX_SCALAR,                      // the return type is a complex scalar
+    2,                                   // there are two input parameters
+    { COMPLEX_SCALAR, COMPLEX_SCALAR }   //    that are both complex scalars
+};


### PR DESCRIPTION
### Description of the Change

This patch fixes several issues with the reverse functions very near the saturation curve.
1. Reverse function t(p,h) and t(p,s) logic did not account for the very short segment of the saturation curve extending into the IF97 Region 3 (mostly supercritical but encloses the critical end of the saturation curve).  This is fixed and verified.  

2. The reverse functions t(p,h) and t(p,s) have an uncertainty of ±25 mK on the returned temperature (_see_ [IAPWS R7-97(2012)](http://www.iapws.org/relguide/IF97-Rev.pdf) _equations 12 and 14_).  This means that if the (p,h) or (p,s) state point is very near the saturation curve in the liquid or vapor regions, the returned temperature can (and often does) on the other side of the saturation curve in the wrong region (see Issue CoolProp/CoolProp#1918).  Use of this temperature and pressure to evaluate additional properties can result in liquid values being returned from the vapor state and vice versa.  In the plot below temperatures are returned alongside the saturation curve with entropy values adjusted slightly into the Liquid region.  Negative differences between Tsat(p) and T(p,h) indicate temps to the right of the saturation curve in the Vapor region.  
  
   ![image](https://github.com/CoolProp/IF97/assets/17114032/ea1e1f30-e163-4475-92f8-1771ee1db06a)  
  
   > NOTE: The errors are an order of magnitude lower in the REGION 3 portion of the saturation curve than in the REGION 1 and REGION 2 portions, probably because the REGION 3 equations are broken down into many small subregions with higher order of accuracy.  

   The fix is to bound the returned temperature value to the saturation temperature @ p, with a very small ±offset of 0.001mK to ensure that the returned temperature is in the same phase region as the (p,h) or (p,s) state point.  
  
   ![image](https://github.com/CoolProp/IF97/assets/17114032/d615868c-8a43-41a4-940b-ad88783b4bd1)
  
3. The correction above can return mild discontinuities across the saturation curve in subsequent property evaluations using the pressure and the reverse temperature determined above.  For thermodynamic cycle calculations involving h(p,s) and/or s(p,h), the IF97 reverse functions can return enthalpy and entropy that are ±200 J/kg and ±0.25 J/kg, respectively, of the forward functions, except at very low pressures and near the critical point where this error can be **_much_** larger.  On average, this is a **_relative error_** of around ±0.015 %, except for at very low pressures where the liquid enthalpy and entropy values get quite low themselves.  This error in the liquid/vapor regions can lead to discontinuities with the 2-phase region (bracketed by saturated liquid/vapor values) when using these reverse functions.  
   
   ![image](https://github.com/CoolProp/IF97/assets/17114032/3d569724-9fe1-476f-a53a-6f453a969528)
   
   Two new API functions are added for `h(p, s)` and `s(p, h)` to alleviate this discontinuity.  These functions use the "un-clipped" temperatures at the saturation points to evaluate the returned property, ensuring that the correct region equations are used in each case to calculate the 2-phase lever rule based on the Q(p,h) or Q(p,s).  This alleviates the discontinuity at the saturation curve but does carry the reverse function error into the 2-phase region.  
   
   ![image](https://github.com/CoolProp/IF97/assets/17114032/a3a26434-3eae-46ef-8e56-75c50ad2727a)
   
   These errors, as discussed above, are small and better than
   * leaving a discontinuity in reverse functions for h and s that would trip up any thermodynamic cycle optimization calculations, and 
   * better than the previous state of returning values from the opposite phase at random.   
4. The above `s(p, h)` and `h(p, s)` functions were also implemented in the Mathcad wrapper for ease of verification testing, units handling, and generation of plots.
5. Because of added reverse functions to API, IF97 version updated to **2.2.0**.

### Benefits

Increases robustness of reverse functions of Pressure and either Enthalpy or Entropy.
* Properly evaluates reverse temperature in REGION 3 portion of saturation curve.
* Returns reverse temperature in same REGION as (p,h) or (p,s), despite reverse function uncertainties of ±25 mK,
* Fixes forward property evaluations using reverse temperature to appropriate region/phase.
* Implements new IF97 API functions for `s(p, h)` and `h(p, s)` that provide continuous reverse evaluations across saturation boundaries in and out of the 2-phase region.

### Possible Drawbacks

Uncertainty in reverse functions of (p,h) or (p,s) are ±25 mK for Temperature (_see_ [IAPWS R7-97(2012)](http://www.iapws.org/relguide/IF97-Rev.pdf) _equations 12 and 14_).  While this is relatively small, forward functions of other properties, especially Enthalpy and Entropy, using these values can result in small but measurable errors from the expected values.  This is just a byproduct of the reverse IF97 functions.  Below is a plot of the error in Entropy using the reverse function of Pressure and Enthalpy along the saturation curves.   

![image](https://github.com/CoolProp/IF97/assets/17114032/27b959f6-31e2-4c16-be09-51de090471fe)

This shows that the Entropy error is ±0.25 J/kg-K for most of the saturation curve.  However, the errors are larger at very low pressures and MUCH larger very near the critical point.  Calculating Enthalpy from reverse functions of Pressure and Entropy yields errors of ±200 J/kg.   Users should be aware of these errors when making use of the reverse IF97 functions of pressure and Enthalpy or Entropy.  Luckily, these kinds of thermodynamic cycle calculations are not usually carried out very near the critical point or in very low-pressure environments.  The errors observed here are still worth the increase in computational speed from the Industrial Formulation, IF97, non-iterative calculations.

### Verification Process

- *How did you verify that all new functionality works as expected?*   

   New reverse functions of `s(p, h)` and `h(p, s)` were evaluated through the Mathcad wrapper and used to plot Enthalpy and Entropy error from the forward functions over the entire range of IF97 temperatures and pressures (plots shown below).   

- *How did you verify that all changed functionality works as expected?*  

   Limiting of reverse function temperatures was verified by generating plots of temperature along near-saturation values of enthalpy and entropy for the entire liquid and vapor saturation ranges, demonstrating that no temperatures were returned from the incorrect phase (sample Entropy curve plots shown above).    Plots were also generated to demonstrate continuity of Enthalpy and Entropy reverse values at various pressure locations along both the liquid and vapor saturation curves.

- *How did you verify that the change has not introduced any regressions?*  

   Standard regression test Mathcad sheet ([if97_validation2024.pdf](https://github.com/user-attachments/files/15848688/if97_validation2024.pdf)) was re-evaluated to ensure that all IAPWS computer program verification points are still within the expected machine round-off of IAPWS published values.  

Reverse function error maps shown here for entire IF97 range of temperatures and pressures.   

![image](https://github.com/CoolProp/IF97/assets/17114032/481d19b9-d70f-4157-8bb3-f27dd87af2dd)

![image](https://github.com/CoolProp/IF97/assets/17114032/1bcaeb17-1993-482d-83b5-fbcda1a78c52)


### Applicable Issues

Closes #48 .

First steps in closing issues CoolProp/CoolProp#1918 and CoolProp/CoolProp#2334.  Both of these will require some mods to the IF97Backend in CoolProp to make use of the new functionality presented here (this has already been completed and tested but not yet incorporated.)
